### PR TITLE
Caching the raw_data result to speed up things

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ 8,122,070
 
 ```
 >>> coinmarketcap.top(10)
-['Bitcoin', 'Ripple', 'Litecoin', 'BitShares', 'Dogecoin', 'Nxt', 'Peercoin', 'Stellar', 'Counterparty', 'Darkcoin']
+['bitcoin', 'ethereum', 'ripple', 'litecoin', 'maidsafecoin', 'dogecoin', 'dash', 'peercoin', 'bitshares', 'stellar']
 ```
 
   - Mineable:

--- a/coinmarketcap/__init__.py
+++ b/coinmarketcap/__init__.py
@@ -11,7 +11,7 @@
 #                                                              |_|
 
 __title__   = 'coinmarketcap'
-__version__ = '1.2'
+__version__ = '1.2.1'
 __author__ = 'Martin Simon <me@martinsimon.me>'
 __repo__    = 'https://github.com/mrsmn/coinmarketcap-api'
 __license__ = 'Apache v2.0 License'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 
 setup(
     name = 'coinmarketcap',
-    version = '1.2',
+    version = '1.2.1',
     url = 'https://github.com/mrsmn/coinmarketcap-api',
     download_url = 'https://github.com/mrsmn/coinmarketcap-api/archive/master.zip',
     author = 'Martin Simon <me@martinsimon.me>',


### PR DESCRIPTION
Thanks for merging the last PR!
Here's another thing I've found useful for what I'm up to. Iterating and doing operations across the whole market cap list is pretty slow when having to re-GET the raw_data, so here I've just added caching until a timeout elapses.

Sorry for incrementing your version number though, it feels presumptuous :/

Cheers!
