### PR TITLE
Added responses in json and symbols requests

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3,4 +3,5 @@ COPYING
 setup.py
 README.md
 coinmarketcap/core.py
+coinmarketcap/up.py
 coinmarketcap/__init__.py

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This API can currently retrieve the following data from [coinmarketcap](http://c
 >>> coinmarketcap.ticker('ETH')
 >>> coinmarketcap.ticker('ethereum')
 
-# Add VERBOSE=True for a string response, like this:
+# Add VERBOSE=True for a more readable string response, like this:
 >>> coinmarketcap.ticker('STEEM', VERBOSE=True)
 
 # Receive all the currencies in a string:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ This API can currently retrieve the following data from [coinmarketcap](http://c
 >>> from coinmarketcap import Market
 >>> coinmarketcap = Market()
 >>> coinmarketcap.ticker(<currency>)
+# <currency> can be passed through 'ethereum' or 'ETH' and returns in json
+
+>>> coinmarketcap.ticker('ETH')
+>>> coinmarketcap.ticker('ethereum')
+
+# Add VERBOSE=True for a string response, like this:
+>>> coinmarketcap.ticker('STEEM', VERBOSE=True)
+
+# Receive all the currencies in a string:
+>>> coinmarketcap.ticker(VERBOSE=True)
 [
   {
     id: "bitcoin",
@@ -62,7 +72,7 @@ This API can currently retrieve the following data from [coinmarketcap](http://c
 - **`GET /v1/global/`**
 
 ```python
->>> coinmarketcap.stats()
+>>> coinmarketcap.stats(VERBOSE=True)
 {
   total_market_cap_usd: 8280726727,
   total_24h_volume_usd: 108644044,

--- a/coinmarketcap/__init__.py
+++ b/coinmarketcap/__init__.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__title__   = 'pymarketcap'
+__title__   = 'coinmarketcap'
 __version__ = '3.0.1'
-__author__ = 'Álvaro Mondéjar <mondejar1994@gmail.com>'
-__repo__    = 'https://github.com/mrsmn/pymarketcap'
+__author__ = 'Martin Simon <me@martinsimon.me>, Álvaro Mondéjar <mondejar1994@gmail.com>'
+__repo__    = 'https://github.com/mrsmn/coinmarketcap-api'
 __license__ = 'Apache v2.0 License'
 
 from .core import Market

--- a/coinmarketcap/__init__.py
+++ b/coinmarketcap/__init__.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__title__   = 'coinmarketcap'
-__version__ = '2.0.1'
-__author__ = 'Martin Simon <me@martinsimon.me>'
-__repo__    = 'https://github.com/mrsmn/coinmarketcap-api'
+__title__   = 'pymarketcap'
+__version__ = '3.0.1'
+__author__ = 'Álvaro Mondéjar <mondejar1994@gmail.com>'
+__repo__    = 'https://github.com/mrsmn/pymarketcap'
 __license__ = 'Apache v2.0 License'
 
 from .core import Market

--- a/coinmarketcap/core.py
+++ b/coinmarketcap/core.py
@@ -2,41 +2,102 @@
 # -*- coding: utf-8 -*-
 
 try:
-	import urllib.request as urllib2
+    import urllib.request as urllib2
 except ImportError:
-	import urllib2
+    import urllib2
+
+def _reimport(update=False):
+    """ Internal function for serves symbols correspondences """
+    from os import path
+    p = path.dirname(path.abspath(__file__))
+    if update == True:
+        from sys import path as pth
+        pth.insert(1, p)
+        import up
+        up.update_currencies()
+        pth.remove(p)
+        if '' in pth:
+            pth.remove('')
+    with open(p + '/temp/currencies.txt', 'r') as f:
+        availables = f.read()
+        from ast import literal_eval as l
+        return l(availables)
 
 class Market(object):
+    def __init__(self, base_url='https://api.coinmarketcap.com/v1/'):
+        self.base_url = base_url
+        self.opener = urllib2.build_opener()
+        self.opener.addheaders.append(('Content-Type', 'application/json'))
+        self.opener.addheaders.append(('User-agent', 'coinmarketcap - python wrapper \
+        around coinmarketcap.com (github.com/mrsmn/coinmarketcap-api)'))
 
-	def __init__(self, base_url='https://api.coinmarketcap.com/v1/'):
-		self.base_url = base_url
-		self.opener = urllib2.build_opener()
-		self.opener.addheaders.append(('Content-Type', 'application/json'))
-		self.opener.addheaders.append(('User-agent', 'coinmarketcap - python wrapper \
-		around coinmarketcap.com (github.com/mrsmn/coinmarketcap-api)'))
+    def _urljoin(self, *args):
+        """ Internal urljoin function because urlparse.urljoin sucks """
+        return "/".join(map(lambda x: str(x).rstrip('/'), args))
 
-	def _urljoin(self, *args):
-		""" Internal urljoin function because urlparse.urljoin sucks """
-		return "/".join(map(lambda x: str(x).rstrip('/'), args))
+    def _get(self, api_call, query):
+        url = self._urljoin(self.base_url, api_call)
+        if query == None:
+            response = self.opener.open(url).read()
+        else:
+            response_url = self._urljoin(url, query)
+            response = self.opener.open(response_url).read()
+        return response
 
-	def _get(self, api_call, query):
-		url = self._urljoin(self.base_url, api_call)
-		if query == None:
-			response = self.opener.open(url).read()
-		else:
-			response_url = self._urljoin(url, query)
-			response = self.opener.open(response_url).read()
-		return response
+    def _up(self, param=None):
+        """ Internal function for update symbols currencies """
+        data = self._get('ticker/', query=param)
+        import json, sys
+        if int(sys.version[0]) < 3:
+            return json.loads(data)
+        else:
+            return json.loads(data.decode('utf-8'))
 
-	def ticker(self, param=None):
-		""" ticker() returns a dict containing all the currencies
-			ticker(currency) returns a dict containing only the currency you
-			passed as an argument.
-		"""
-		data = self._get('ticker/', query=param)
-		return data
+    def ticker(self, param=None, VERBOSE=False):
+        """ ticker() returns a dict containing all the currencies
+            ticker(currency) returns a dict containing only the currency you
+            passed as an argument.
+            
+            VERBOSE=False (as default) -> ticker() return in json
+            VERBOSE=True -> ticker() return a string
+        """
+        if param != None:
+            if param.isupper() == True:
+                try:
+                    availables = _reimport()
+                except IOError:
+                    availables = _reimport(update=True)
+                if param in availables:
+                    param = availables.get(param)
+                else: # If the coin isn't in the dict
+                    availables = _reimport(update=True)
+                    if param not in availables:
+                        exc = "The currency %s isn't in coinmarketcap" % param
+                        raise NameError(exc)
+                
+        data = self._get('ticker/', query=param)
+        if VERBOSE == True:
+            return data
+        else:
+            import json, sys
+            if int(sys.version[0]) < 3:
+                return json.loads(data)
+            else:
+                return json.loads(data.decode('utf-8'))
+        
+        
+    def stats(self, VERBOSE=False):
+        """ stats() returns a dict containing cryptocurrency statistics.
 
-	def stats(self):
-		""" stats() returns a dict containing cryptocurrency statistics. """
-		data = self._get('global/', query=None)
-		return data
+            VERBOSE=False (as default) -> stats() return a dict
+            VERBOSE=True -> stats() return a string
+        """
+        data = self._get('global/', query=None)
+        if VERBOSE == True:
+            return data
+        else:
+            import json, sys
+            if int(sys.version[0]) < 3:
+                return json.loads(data)
+            else:
+                return json.loads(data.decode('utf-8'))

--- a/coinmarketcap/up.py
+++ b/coinmarketcap/up.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+''' Return a dic with all the available currencies
+and their symbols correspondences '''
+def get_currencies():
+        from core import Market
+        dic = {}
+        for currency in Market()._up():
+            iid = currency.get('id')
+            symbol = currency.get('symbol')
+            dic[symbol] = iid
+        return dic
+
+''' Save the symbols in a temporary .txt file '''
+def update_currencies():
+    from os import path
+    p = path.dirname(path.abspath(__file__))
+    try:
+        c = open(p + '/temp/currencies.txt', 'w')
+    except IOError:
+        from os import mkdir
+        mkdir(p + '/temp')
+        c = open(p + '/temp/currencies.txt', 'w')
+    c.write(str(get_currencies()))
+    c.close()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 
 setup(
     name = 'coinmarketcap',
-    version = '2.0.1',
+    version = '3.0.1',
     url = 'https://github.com/mrsmn/coinmarketcap-api',
     download_url = 'https://github.com/mrsmn/coinmarketcap-api/archive/master.zip',
     author = 'Martin Simon <me@martinsimon.me>',


### PR DESCRIPTION
Now we can request `coinmarketcap.ticker('ETH')` and through the old way `coinmarketcap.ticker('ethereum')` also. The default return is in json.

If you want a more readable reponse in a string, request `coinmarketcap.ticker('ETH', VERBOSE=True)`, `coinmarketcap.ticker('ethereum', VERBOSE=True)` or `coinmarketcap.stats(VERBOSE=True)`. 